### PR TITLE
fix use of deprecated std.c.stdlib

### DIFF
--- a/source/docopt.d
+++ b/source/docopt.d
@@ -16,7 +16,7 @@ import std.container;
 import std.traits;
 import std.ascii;
 import std.conv;
-import std.c.stdlib;
+import core.stdc.stdlib;
 import std.json;
 
 import argvalue;

--- a/source/patterns.d
+++ b/source/patterns.d
@@ -17,7 +17,7 @@ import std.container;
 import std.traits;
 import std.ascii;
 import std.conv;
-import std.c.stdlib;
+import core.stdc.stdlib;
 
 import argvalue;
 


### PR DESCRIPTION
see docopt/docopt.d#5. trivial fix.

Passes tests on Linux with dmd v2.070.0 and on OSX with dmd v2.069.2.